### PR TITLE
Updated Windows Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhosty
 
 ## Installation (Windows):
 
-### Installation using WSL (recommended): TODO
+Installation using WSL (recommended): TODO
 
-### Installation using Cygwin, Git Bash or similar: [Here](docs/Cygwin-Git-Bash.md)
+
+Installation using Cygwin, Git Bash or similar: [Here](docs/Cygwin-Git-Bash.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,33 +43,9 @@ Download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhosty
 
 ## Installation (Windows):
 
-### Installation using WSL (recommended):
+### Installation using WSL (recommended): TODO
 
-TODO
-
-### Installation using Cygwin, Git Bash or similar:
-
-#### Known Issues
-* Windows has a hard limit of 260 characters for the filepath. This can cause issues with video downloading. It is recommended that you make your filepath as short as possible.
-* If you are receiving a permission denied error when attempting to execute python, [this thread](https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10) may be helpful.
-
-#### Required Software
-In order to run these scripts, the following software packages must be installed:
-
-* [Cygwin](https://www.cygwin.com/), [Git Bash](http://git-scm.com), or some other application that enables Bash functionality in Windows.
-* [Python 3](https://www.python.org/downloads/)
-* [yt-dlp](https://github.com/pukkandan/yt-dlp) - Make sure this is in your PATH.
-* [ffmpeg](https://www.ffmpeg.org/) - Make sure this is in your PATH.
-* [atomicparsley](https://github.com/wez/atomicparsley) (optional) - Make sure this is in your PATH.
-
-#### Configuration
-First, make sure that all dependencies are installed and your PATH is configured properly by opening your Bash terminal of choice and executing the following:
-
-* `python --version`
-* `yt-dlp --version`
-* `ffmpeg --version`
-
-If all of the above commands execute correctly, download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts/releases) and follow the "Usage" section of this README.
+### Installation using Cygwin, Git Bash or similar: [Here](docs/Cygwin-Git-Bash.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ Download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhosty
 
 TODO
 
-### Installation using Cygwin, Git Bash or similar;
+### Installation using Cygwin, Git Bash or similar:
 
 #### Known Issues
-* Windows has a hard limit of 260 characters for the filepath.  This can cause issues with video downloading.  It is recommended that you make your filepath as short as possible.
+* Windows has a hard limit of 260 characters for the filepath. This can cause issues with video downloading. It is recommended that you make your filepath as short as possible.
 * If you are receiving a permission denied error when attempting to execute python, [this thread](https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10) may be helpful.
-* yt-dlp must be named "yt-dlp.exe".  This means if you down the x86 version, you will need to rename it or create a symlink.
 
 #### Required Software
 In order to run these scripts, the following software packages must be installed:
@@ -61,7 +60,7 @@ In order to run these scripts, the following software packages must be installed
 * [Python 3](https://www.python.org/downloads/)
 * [yt-dlp](https://github.com/pukkandan/yt-dlp) - Make sure this is in your PATH.
 * [ffmpeg](https://www.ffmpeg.org/) - Make sure this is in your PATH.
-* [atomicparsley](https://github.com/wez/atomicparsley) (optional)
+* [atomicparsley](https://github.com/wez/atomicparsley) (optional) - Make sure this is in your PATH.
 
 #### Configuration
 First, make sure that all dependencies are installed and your PATH is configured properly by opening your Bash terminal of choice and executing the following:

--- a/README.md
+++ b/README.md
@@ -43,11 +43,28 @@ Download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhosty
 
 ## Installation (Windows):
 
-Setup Windows Subsystem for Linux (WSL) and follow the Linux installation.
+### Known Issues
+* Windows has a hard limit of 260 characters for the filepath.  This can cause issues with video downloading.  It is recommended that you make your filepath as short as possible.
+* If you are receiving a permission denied error when attempting to execute python, [this thread](https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10) may be helpful.
+* yt-dlp must be named "yt-dlp.exe".  This means if you down the x86 version, you will need to rename it or create a symlink.
 
-Detailed setup instruction need to be added to the documentation.
+### Required Software
+In order to run these scripts, the following software packages must be installed:
 
-Why: Because Windows is using a path length limit of 260 characters, and because of the work required (and the fact that the Windows version was untested when it existed), Windows users needs to use the scripts in WSL. WSL bypass the path length limit so every video will get downloaded, however when playing it with a native Windows software the path length issue might be an issue, I can't do anything about that.
+* [Cygwin](https://www.cygwin.com/), [Git Bash](http://git-scm.com), or some other application that enables Bash functionality in Windows.
+* [Python 3](https://www.python.org/downloads/)
+* [yt-dlp](https://github.com/pukkandan/yt-dlp) - Make sure this is in your PATH.
+* [ffmpeg](https://www.ffmpeg.org/) - Make sure this is in your PATH.
+* [atomicparsley](https://github.com/wez/atomicparsley) (optional)
+
+### Configuration
+First, make sure that all dependencies are installed and your PATH is configured properly by opening your Bash terminal of choice and executing the following:
+
+* `python --version`
+* `yt-dlp --version`
+* `ffmpeg --version`
+
+If all of the above commands execute correctly, download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts/releases) and follow the "Usage" section of this README.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,18 @@ Download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhosty
 
 ## Installation (Windows):
 
-### Known Issues
+### Installation using WSL (recommended):
+
+TODO
+
+### Installation using Cygwin, Git Bash or similar;
+
+#### Known Issues
 * Windows has a hard limit of 260 characters for the filepath.  This can cause issues with video downloading.  It is recommended that you make your filepath as short as possible.
 * If you are receiving a permission denied error when attempting to execute python, [this thread](https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10) may be helpful.
 * yt-dlp must be named "yt-dlp.exe".  This means if you down the x86 version, you will need to rename it or create a symlink.
 
-### Required Software
+#### Required Software
 In order to run these scripts, the following software packages must be installed:
 
 * [Cygwin](https://www.cygwin.com/), [Git Bash](http://git-scm.com), or some other application that enables Bash functionality in Windows.
@@ -57,7 +63,7 @@ In order to run these scripts, the following software packages must be installed
 * [ffmpeg](https://www.ffmpeg.org/) - Make sure this is in your PATH.
 * [atomicparsley](https://github.com/wez/atomicparsley) (optional)
 
-### Configuration
+#### Configuration
 First, make sure that all dependencies are installed and your PATH is configured properly by opening your Bash terminal of choice and executing the following:
 
 * `python --version`

--- a/docs/Cygwin-Git-Bash.md
+++ b/docs/Cygwin-Git-Bash.md
@@ -1,0 +1,23 @@
+### Installation using Cygwin, Git Bash or similar:
+
+#### Known Issues
+* Windows has a hard limit of 260 characters for the filepath. This can cause issues with video downloading. It is recommended that you make your filepath as short as possible.
+* If you are receiving a permission denied error when attempting to execute python, [this thread](https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10) may be helpful.
+
+#### Required Software
+In order to run these scripts, the following software packages must be installed:
+
+* [Cygwin](https://www.cygwin.com/), [Git Bash](http://git-scm.com), or some other application that enables Bash functionality in Windows.
+* [Python 3](https://www.python.org/downloads/)
+* [yt-dlp](https://github.com/pukkandan/yt-dlp) - Make sure this is in your PATH.
+* [ffmpeg](https://www.ffmpeg.org/) - Make sure this is in your PATH.
+* [atomicparsley](https://github.com/wez/atomicparsley) (optional) - Make sure this is in your PATH.
+
+#### Configuration
+First, make sure that all dependencies are installed and your PATH is configured properly by opening your Bash terminal of choice and executing the following:
+
+* `python --version`
+* `yt-dlp --version`
+* `ffmpeg --version`
+
+If all of the above commands execute correctly, download the latest [release](https://github.com/TheFrenchGhosty/TheFrenchGhostys-YouTube-DL-Archivist-Scripts/releases) and follow the "Usage" section of this README.


### PR DESCRIPTION
Related to #47 

Should cover any installation that enables bash on Windows.  Functionality tested.  Main issue continues to be the Windows filepath size limitation.